### PR TITLE
Update parse_git_dirty() due to git status change

### DIFF
--- a/.bash_prompt
+++ b/.bash_prompt
@@ -40,7 +40,7 @@ fi
 
 
 function parse_git_dirty() {
-	[[ $(git status 2> /dev/null | tail -n1) != "nothing to commit (working directory clean)" ]] && echo "*"
+	[[ $(git status 2> /dev/null | tail -n1 | awk '{print $1}') != "nothing" ]] && echo "*"
 }
 
 function parse_git_branch() {


### PR DESCRIPTION
`git status` outputs

```
nothing to commit (working directory clean)
```

on v1.7

but it has since updated to

```
nothing to commit, working directory clean
```

on v1.8

This pull request updates `parse_git_dirty()` so it will accompany both versions.
