### PR TITLE
Added if statement to check if Sublime symlink needs to be added

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -8,10 +8,7 @@ alias ~="cd ~" # `cd` is probably faster to type though
 alias -- -="cd -"
 
 # setting up the sublime symlink
-if [ ! -L ~/bin/subl ]
-then
-    ln -s "/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl" ~/bin/subl
-fi
+ln -sf "/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl" ~/bin/subl
 
 # i <3 u cask
 alias cask='brew cask'

--- a/.aliases
+++ b/.aliases
@@ -7,9 +7,11 @@ alias .....="cd ../../../.."
 alias ~="cd ~" # `cd` is probably faster to type though
 alias -- -="cd -"
 
-# the subl symlink was probably set up already but in case it wasn't…
-# ln -s "/Applications/Sublime Text 2.app/Contents/SharedSupport/bin/subl" ~/bin/subl
-
+# setting up the sublime symlink
+if [ ! -L ~/bin/subl ]
+then
+    ln -s "/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl" ~/bin/subl
+fi
 
 # i <3 u cask
 alias cask='brew cask'


### PR DESCRIPTION
Hi Paul, thanks for a some really cool dotfiles!

This change will check if the sublime symlink exists before adding it (assuming it is not commented), so the message in the attached image never shows. What do you think about it?
![dotfiles-paul-symlink](https://cloud.githubusercontent.com/assets/1140124/5019055/4986b432-6abc-11e4-9cb1-f4379bc8859a.png)

Best Regards,
Niklas