### PR TITLE
setup-a-new-machine.sh: improved Xcode install

### DIFF
--- a/setup-a-new-machine.sh
+++ b/setup-a-new-machine.sh
@@ -69,20 +69,39 @@ cp "~/Library/Application Support/Sublime Text 3/Packages" ~/migration
 
 ##############################################################################################################
 ### XCode Command Line Tools
-#      thx  https://github.com/alrra/dotfiles/blob/c2da74cc333/os/os_x/install_applications.sh#L39
+#      thx https://github.com/alrra/dotfiles/blob/ff123ca9b9b/os/os_x/installs/install_xcode.sh
 
-if [ $(xcode-select -p &> /dev/null; printf $?) -ne 0 ]; then
+if ! xcode-select --print-path &> /dev/null; then
+
+    # Prompt user to install the XCode Command Line Tools
     xcode-select --install &> /dev/null
+
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
     # Wait until the XCode Command Line Tools are installed
-    while [ $(xcode-select -p &> /dev/null; printf $?) -ne 0 ]; do
+    until xcode-select --print-path &> /dev/null; do
         sleep 5
     done
-	xcode-select -p &> /dev/null
-	if [ $? -eq 0 ]; then
-        # Prompt user to agree to the terms of the Xcode license
-        # https://github.com/alrra/dotfiles/issues/10
-       sudo xcodebuild -license
-   fi
+
+    print_result $? 'Install XCode Command Line Tools'
+
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+    # Point the `xcode-select` developer directory to
+    # the appropriate directory from within `Xcode.app`
+    # https://github.com/alrra/dotfiles/issues/13
+
+    sudo xcode-select -switch /Applications/Xcode.app/Contents/Developer
+    print_result $? 'Make "xcode-select" developer directory point to Xcode'
+
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+    # Prompt user to agree to the terms of the Xcode license
+    # https://github.com/alrra/dotfiles/issues/10
+
+    sudo xcodebuild -license
+    print_result $? 'Agree with the XCode Command Line Tools licence'
+
 fi
 ###
 ##############################################################################################################
@@ -196,6 +215,3 @@ sh .osx
 
 ###
 ##############################################################################################################
-
-
-


### PR DESCRIPTION
Running a command and then explicitly asking for its return code and comparing that to a given value is needlessly complex. Simply remove the  `[…]` and we get the exit status for free.

There’s no need to recheck on `xcode-select`, since the loop won’t let it continue until it is done. If for some reason the loop was mistaken, so would be this check.

Changed the short `-p` to the more verbose `--print-path`. Having short flags in a script isn’t particularly useful. It doesn’t make any relevant difference in speed, but it does make a relevant difference in comprehension.

Finally, no need to `while` for a negative result when we have `until`.