### PR TITLE
update gnu-sed install param

### DIFF
--- a/brew.sh
+++ b/brew.sh
@@ -15,7 +15,7 @@ brew install moreutils
 # GNU `find`, `locate`, `updatedb`, and `xargs`, `g`-prefixed
 brew install findutils
 # GNU `sed`, overwriting the built-in `sed`
-brew install gnu-sed --default-names
+brew install gnu-sed --with-default-names
 
 
 # Bash 4


### PR DESCRIPTION
The deprecated parameter ```--default-names``` raises the following warning:

```
Warning: gnu-sed: --default-names was deprecated; using --with-default-names instead!
```