### PR TITLE
Allow sequenced command to run

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -27,7 +27,7 @@
 
 # so much color
 [color]
-	ui = always
+	ui = auto
 [color "diff"]
 	meta = yellow bold
 	commit = green bold


### PR DESCRIPTION
When `!gcm && git branch --merged | grep -v '\\*' | xargs -n 1 git branch -d` is run the `git branch --merged` will return the colourization  branch which make the `xargs git branch -d` invalid! Usually its throws with error saying the `branch not found`.

more info: http://stackoverflow.com/questions/23355169/xargs-doesnt-work-on-mac-when-given-output-from-git-branch
