### PR TITLE
Add link to repositories of paulmillr and gf3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 * I maintain this repo as *my* dotfiles, but I'm keenly aware people are using it for theirs.
 * You're quite welcome to make suggestions, however I may decline if it's not of personal value to me.
-* If you're starting off consider forking [mathias](https://github.com/mathiasbynens/dotfiles/) or [alrra](https://github.com/alrra/dotfiles/). paulmillr and gf3 also have great setups
+* If you're starting off consider forking [mathias](https://github.com/mathiasbynens/dotfiles/) or [alrra](https://github.com/alrra/dotfiles/). [paulmillr](https://github.com/paulmillr/dotfiles) and [gf3](https://github.com/gf3/dotfiles) also have great setups
 
 ## Setup
 #### installing & using


### PR DESCRIPTION
Hi @paulirish, I noticed that the link for dotfiles of paulmillr and gf3 were missing, so, I added in readme.