### PR TITLE
Enable the pager to use the scroll wheel

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -19,8 +19,8 @@
 
 [pager]
 	# insanely beautiful diffs ==> npm install -g diff-so-fancy
-	diff = diff-so-fancy | less --tabs=4 -RFX
-	show = diff-so-fancy | less --tabs=4 -RFX
+	diff = diff-so-fancy | less --tabs=4 -R
+	show = diff-so-fancy | less --tabs=4 -R
 
 [interactive]
 	diffFilter = "diff-so-fancy"


### PR DESCRIPTION
By removing the `FX` flags from the `less` pager, it's scrollable with the touchpad / scroll wheel.

I think it's a good quality of life improvement.
