### PR TITLE
Add \[ \] around styling to avoid breakage.

### DIFF
--- a/.bash_prompt
+++ b/.bash_prompt
@@ -81,10 +81,10 @@ set_prompts() {
         fi;
 
         userhost=""
-        userhost+="\[${userStyle}\]$USER "
-        userhost+="${white}at "
-        userhost+="${orange}$HOSTNAME "
-        userhost+="${white}in"
+        userhost+="\[${userStyle}\]$USER"
+        userhost+="\[${white}\]at "
+        userhost+="\[${orange}\]$HOSTNAME "
+        userhost+="\[${white}\]in"
 
         if [ $USER != "$default_username" ]; then echo $userhost ""; fi
     }

--- a/.bash_prompt
+++ b/.bash_prompt
@@ -81,7 +81,7 @@ set_prompts() {
         fi;
 
         userhost=""
-        userhost+="\[${userStyle}\]$USER"
+        userhost+="\[${userStyle}\]$USER "
         userhost+="\[${white}\]at "
         userhost+="\[${orange}\]$HOSTNAME "
         userhost+="\[${white}\]in"


### PR DESCRIPTION
Without the brackets, removing new lines from the prompt seems to break the reverse search. Took me a while to hunt down. Hopefully this will help others.