### PR TITLE
Fix VS Code 'code' command

### DIFF
--- a/.functions
+++ b/.functions
@@ -168,11 +168,6 @@ webmify(){
 # direct it all to /dev/null
 function nullify() {
   "$@" >/dev/null 2>&1
-}
-
-
-# visual studio code. a la `subl`
-function code () { VSCODE_CWD="$PWD" open -n -b "com.microsoft.VSCodeInsiders" --args $*; }
 
 # `shellswitch [bash |zsh]`
 #   Must be in /etc/shells


### PR DESCRIPTION
Removed `code` command because
* VS Code already has a `Shell Command: Install code command in PATH` command in its own command palette which re-creates the intended functionality
* this `code` function does not work with VS Code's current build