### PR TITLE
Fixed issue with cloning

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -107,8 +107,7 @@
     # Show blocks of moved text of at least 20 alphanumeric characters differently than adds/deletes
     # https://blog.github.com/2018-04-05-git-217-released/
     colorMoved = zebra
-[remote "origin"]
-	fetch = +refs/heads/*:refs/remotes/origin/*
+
 [stash]
 	showPatch = true
 [log]


### PR DESCRIPTION
Hey Paul,

I'm not sure why, but the following config parameter seems to have broken the ability to clone repos:

```
[remote "origin"]
	fetch = +refs/heads/*:refs/remotes/origin/*
```

`git v.2.20.0` was just released a few days ago, so perhaps something changed underneath the hood (I need to check out the release notes).

Anyways, feel free to merge this if it helps you out :)

Cheers!