### PR TITLE
Remove duplicate npm install --global diff-so-fancy

### DIFF
--- a/setup-a-new-machine.sh
+++ b/setup-a-new-machine.sh
@@ -159,9 +159,6 @@ npm install -g git-open
 # fancy listing of recent branches
 npm install -g git-recent
 
-# sexy git diffs
-npm install -g diff-so-fancy
-
 # trash as the safe `rm` alternative
 npm install --global trash-cli
 


### PR DESCRIPTION
If merged, this will reduce the number of calls to `npm install -g diff-so-fancy` to one.

Note I remove the first call since the second is more explicit — it uses `--global`.  The one I removed used just `-g`.
 
[Here is the call to `npm install --global diff-so-fancy`](https://github.com/StevenBlack/dotfiles-1/blob/1c4826870bbc203f18e1a0414ef7ac880e36546b/setup-a-new-machine.sh#L165-L166) which remains in place.