### PR TITLE
Convert typo aliases to abbreviations

### DIFF
--- a/fish/aliases.fish
+++ b/fish/aliases.fish
@@ -24,11 +24,6 @@ alias chmox='chmod +x'
 alias cask='brew cask' # i <3 u cask
 alias where=which # sometimes i forget
 
-# typos
-alias brwe=brew  
-alias gti=git
-alias yearn=yarn
-
 alias hosts='sudo $EDITOR /etc/hosts'   # yes I occasionally 127.0.0.1 twitter.com ;)
 
 alias push="git push"

--- a/fish/aliases.fish
+++ b/fish/aliases.fish
@@ -24,6 +24,11 @@ alias chmox='chmod +x'
 alias cask='brew cask' # i <3 u cask
 alias where=which # sometimes i forget
 
+# typos
+abbr bwre brew
+abbr gti git
+abbr yearn yarn
+
 alias hosts='sudo $EDITOR /etc/hosts'   # yes I occasionally 127.0.0.1 twitter.com ;)
 
 alias push="git push"

--- a/fish/config.fish
+++ b/fish/config.fish
@@ -102,10 +102,6 @@ set -gx LESS_TERMCAP_so \e'[38;5;246m'    # begin standout-mode - info box
 set -gx LESS_TERMCAP_ue \e'[0m'           # end underline
 set -gx LESS_TERMCAP_us \e'[04;38;5;146m' # begin underline
 
-# typos
-abbr bwre brew
-abbr gti git
-abbr yearn yarn
 
 # this currently messes with newlines in my prompt. lets debug it later.
 # test -e {$HOME}/.iterm2_shell_integration.fish ; and source {$HOME}/.iterm2_shell_integration.fish

--- a/fish/config.fish
+++ b/fish/config.fish
@@ -102,6 +102,10 @@ set -gx LESS_TERMCAP_so \e'[38;5;246m'    # begin standout-mode - info box
 set -gx LESS_TERMCAP_ue \e'[0m'           # end underline
 set -gx LESS_TERMCAP_us \e'[04;38;5;146m' # begin underline
 
+# typos
+abbr bwre brew
+abbr gti git
+abbr yearn yarn
 
 # this currently messes with newlines in my prompt. lets debug it later.
 # test -e {$HOME}/.iterm2_shell_integration.fish ; and source {$HOME}/.iterm2_shell_integration.fish


### PR DESCRIPTION
This should be considered more of a “Hey, did you know about…?” than a pull request.

Fish has an `abbr` command that lets you replace one string, when used as a command, with another. (The substitution can be shorter than the original, e.g. `yarn` in place of `yearn`, so `abbr` can be a bit of a misnomer.)

https://fishshell.com/docs/current/commands.html#abbr

The principal difference between an `abbr` and an `alias` is that the `abbr` substitution happens _as you type_, which I happen to find kind of neat. More practically, it means that you don't have to search your command history for all possible variations of its name. I don't have to go digging for all instances of `git` _and_ `gti` when trying to recall something I did recently, because the latter were transformed to `git` before I hit return.

Hope you find this edifying and/or useful. Thanks for sharing all of your dotfiles!