### PR TITLE
Fix typo in .functions

### DIFF
--- a/.functions
+++ b/.functions
@@ -168,6 +168,7 @@ webmify(){
 # direct it all to /dev/null
 function nullify() {
   "$@" >/dev/null 2>&1
+}
 
 # `shellswitch [bash |zsh]`
 #   Must be in /etc/shells


### PR DESCRIPTION
Accidentally introduced in last PR touching this file. This fixes the `zsh parse error near `\n` error.