### PR TITLE
Clean up the `HISTIGNORE` Bash variable

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -60,7 +60,7 @@ export HISTFILESIZE=$HISTSIZE                   # big big history
 type shopt &> /dev/null && shopt -s histappend  # append to history, don't overwrite it
 
 # Don't record some commands
-export HISTIGNORE="&:[ ]*:exit:ls:bg:fg:history:clear"
+export HISTIGNORE="exit:ls:bg:fg:history:clear"
 
 # Save multi-line commands as one command
 shopt -s cmdhist


### PR DESCRIPTION
The following passage from the [_Bash Reference Manual_](https://www.gnu.org/software/bash/manual/bash.html#index-HISTIGNORE) provides the background for the proposed changes:
> `HISTIGNORE` subsumes the function of `HISTCONTROL`. A pattern of ‘`&`’ is identical to `ignoredups`, and a pattern of ‘`[ ]*`’ is identical to `ignorespace`. Combining these two patterns, separating them with a colon, provides the functionality of `ignoreboth`.

The relevant section as it stands:
https://github.com/paulirish/dotfiles/blob/89368927c21c6af97d0d604a5433479ec82bda80/.bash_profile#L57-L63

Specifically, this PR is aimed at ironing out these kinks:

1. Having both `&` in `HISTIGNORE` and `ignoredups` in `HISTCONTROL` is redundant.
2. Assuming the intention was to preserve commands with a leading space (as indicated by the comment in Line 57), the inclusion of  `[ ]*` in `HISTIGNORE` is self-defeating.