### PR TITLE
[distill-page] Fix large text in list-item extraction

### DIFF
--- a/agents/skills/distill-page/scripts/decode_annotations.ts
+++ b/agents/skills/distill-page/scripts/decode_annotations.ts
@@ -99,6 +99,7 @@ interface ParserState {
   imageCounter: {value: number};
   insideParagraph: boolean;
   insideHeading: boolean;
+  insideListItem: boolean;
   insideCodeBlock: boolean;
   currentUrl?: string | null;
 }
@@ -358,7 +359,12 @@ export const AnnotationParser = {
     const bold = !!(textData.textStyle?.hasEmphasis && !state.insideHeading);
 
     const size = textData.textStyle?.textSize;
-    if ((size === TextSize.XL || size === TextSize.L) && !state.insideHeading && !state.insideParagraph) {
+    if (
+      (size === TextSize.XL || size === TextSize.L) &&
+      !state.insideHeading &&
+      !state.insideParagraph &&
+      !state.insideListItem
+    ) {
       const headingTextRun: ASTTextRun = {
         type: 'text',
         text: trimmed,
@@ -468,7 +474,7 @@ export const AnnotationParser = {
     const items: ASTListItem[] = [];
     if (node.childrenNodes) {
       for (const itemNode of node.childrenNodes) {
-        const childState = {...state, insideParagraph: false};
+        const childState = {...state, insideParagraph: false, insideListItem: true};
         const itemChildren = this.parseChildren(itemNode.childrenNodes || [itemNode], childState);
         if (itemChildren.length > 0) {
           items.push({
@@ -625,6 +631,7 @@ export const AnnotationParser = {
       imageCounter: {value: 1},
       insideParagraph: false,
       insideHeading: false,
+      insideListItem: false,
       insideCodeBlock: false,
       currentUrl: decodedProto.mainFrameData?.url,
     };

--- a/agents/skills/distill-page/test/cdp.test.ts
+++ b/agents/skills/distill-page/test/cdp.test.ts
@@ -60,6 +60,22 @@ test('does not let an inline article card truncate browser extraction', async ()
   assert.ok(markdown.includes('This conclusion confirms that extraction reaches the end'), 'Should include content after every card');
 });
 
+test('does not treat large ordered-list text as headings', async () => {
+  const fixturePath = path.resolve(__dirname, 'fixtures', 'large-text-ordered-list.html');
+  const content = await fetchDistilledBase64(`file://${fixturePath}`);
+  const markdown = convertToMarkdown(decodeAnnotatedPageContent(content));
+
+  assert.ok(markdown.includes('1. First, a plain entry'), 'Should keep large ordered-list text without heading markers');
+  assert.ok(
+    markdown.includes('2. You put the `html` in the `markdown`, right'),
+    'Should keep large ordered-list text on one line without heading markers',
+  );
+  assert.ok(
+    markdown.includes('1. ## Actual Heading\n  First paragraph\n  Second!'),
+    'Should preserve explicit headings and multiple paragraphs inside list items',
+  );
+});
+
 test('CDP Page.getAnnotatedPageContent on mock-page.html', async () => {
   const mockPagePath = path.resolve(__dirname, 'fixtures/mock-page.html');
   const mockPageUrl = `file://${mockPagePath}`;

--- a/agents/skills/distill-page/test/fixtures/large-text-ordered-list.html
+++ b/agents/skills/distill-page/test/fixtures/large-text-ordered-list.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Large-text ordered list</title>
+    <style>
+      .large-text {
+        font-size: 26px;
+      }
+    </style>
+  </head>
+  <body>
+    <ol class="large-text">
+      <li>First, a plain entry</li>
+      <li>You put the <code>html</code> in the <code>markdown</code>, right</li>
+    </ol>
+
+    <ol>
+      <li>
+        <h2>Actual Heading</h2>
+        <p>First paragraph</p>
+        <p>Second!</p>
+      </li>
+    </ol>
+  </body>
+</html>


### PR DESCRIPTION
Right now, if there are list items on a page and the rendered font size is large, `distill-page` tries to turn the text into headings. So

```html
<ol style="font-size: 26px;">
  <li>Text</li>
</ol>
```

turns into

`1. ## Text`

This gets really messed up with e.g. inline `<code>`, where

```html
<ol style="font-size: 26px;">
  <li>The <code>distill-page</code> skill</li>
</ol>
```

gets turned into 

```
1. ## The
  ## `
  ## distill-page
  ## `
  ## skill
```

To fix this, like in `insideParagraph`, this change makes it so large text in a list item isn't automatically a heading. You can still get headings from explicit heading elements in the list item, though.

To do that, another parser state variable—`insideListItem`—is added. AFAICT `insideParagraph` could have been successfully re-used insetad, and that would cut down on parser states, but overloading the state like that seemed hacky. It could also be renamed into some new variable (`insideNonAutoHeadingContent`), but maybe that's too generalized for what could end up being just two states to handle this.

Also added a test page for it. Kind of slow to start yet another chromium instance, but let me know if that should be done a different way.

(also, also, no idea what's going on with `CDP Page.getAnnotatedPageContent on mock-page.html`, it keeps overwriting with local paths and failing, but it was doing that before I made these changes too :)