### PR TITLE
[distill-page] replace failed iframes with links to src

### DIFF
--- a/agents/skills/distill-page/scripts/decode_annotations.ts
+++ b/agents/skills/distill-page/scripts/decode_annotations.ts
@@ -1,6 +1,6 @@
 import {fromBinary, create} from '@bufbuild/protobuf';
 import {AnnotatedPageContentSchema, AnnotatedRole, ContentAttributeType, TextSize, TableRowType, TextStyleSchema, ContentNodeSchema} from './proto/common_quality_data_pb.js';
-import type {ContentNode, AnnotatedPageContent, TextInfo, ImageInfo, AnchorData, TableData} from './proto/common_quality_data_pb.js';
+import type {ContentNode, AnnotatedPageContent, TextInfo, ImageInfo, AnchorData, TableData, IframeData} from './proto/common_quality_data_pb.js';
 import {INLINE_CODE_CLOSE_MARKER, INLINE_CODE_OPEN_MARKER, PRE_CLOSE_MARKER, PRE_OPEN_MARKER} from './semantic_markers.ts';
 
 const {
@@ -37,7 +37,13 @@ export interface ASTLink {
   children: ASTInlineNode[];
 }
 
-export type ASTInlineNode = ASTTextRun | ASTLink | ASTImage;
+export interface ASTEmbed {
+  type: 'embed';
+  url: string;
+  label: string;
+}
+
+export type ASTInlineNode = ASTTextRun | ASTLink | ASTImage | ASTEmbed;
 
 export interface ASTParagraph {
   type: 'paragraph';
@@ -188,7 +194,7 @@ export const AnnotationParser = {
   },
 
   isInlineNode(node: ASTBlockNode | ASTInlineNode): node is ASTInlineNode {
-    return node.type === 'text' || node.type === 'link' || node.type === 'image';
+    return node.type === 'text' || node.type === 'link' || node.type === 'image' || node.type === 'embed';
   },
 
   parseChildrenFlat(nodes: ContentNode[], state: ParserState): (ASTBlockNode | ASTInlineNode)[] {
@@ -287,7 +293,7 @@ export const AnnotationParser = {
                 const nodeState = {...state};
                 const items = this.parseNode(virtualTextNode, nodeState);
                 for (const item of items) {
-                  if (item.type === 'text' || item.type === 'link' || item.type === 'image') {
+                  if (item.type === 'text' || item.type === 'link' || item.type === 'image' || item.type === 'embed') {
                     inlineAccumulator.push(item);
                   } else if (item.type === 'paragraph') {
                     inlineAccumulator.push(...item.children);
@@ -453,6 +459,30 @@ export const AnnotationParser = {
       return [link];
     }
     return [];
+  },
+
+  parseIframeNode(node: ContentNode, iframeData: IframeData, state: ParserState): (ASTBlockNode | ASTInlineNode)[] {
+    const defaultParsed = this.parseDefaultNode(node, state);
+
+    // Failed iframes will have the hostname and 'refused to connect.' as adjacent text nodes.
+    // Convert these into links to what was embedded.
+    const refusedIndex = defaultParsed.findIndex(n => n.type === 'text' && n.text === 'refused to connect.');
+    const possibleHostnameNode = defaultParsed[refusedIndex - 1];
+    if (refusedIndex > 0 && possibleHostnameNode.type === 'text' && iframeData.data.case === 'frameData') {
+      const possibleHostname = possibleHostnameNode.text;
+      const frameUrl = iframeData.data.value.url;
+      const parsedUrl = URL.parse(iframeData.data.value.url);
+
+      if (parsedUrl?.hostname === possibleHostname) {
+        return [{
+          type: 'embed',
+          url: frameUrl,
+          label: `Link to ${parsedUrl.hostname} embed`,
+        }];
+      }
+    }
+
+    return defaultParsed;
   },
 
   parseParagraphNode(node: ContentNode, state: ParserState): ASTParagraph[] {
@@ -623,6 +653,8 @@ export const AnnotationParser = {
         return this.parseImageNode(node, attrs.contentData.value, state);
       case 'anchorData':
         return this.parseAnchorNode(node, attrs.contentData.value, state);
+      case 'iframeData':
+        return this.parseIframeNode(node, attrs.contentData.value, state);
     }
 
     // 2. Dispatch by structural attribute type
@@ -808,6 +840,9 @@ export const MarkdownSerializer = {
     }
     if (node.type === 'image') {
       return this.serializeImage(node);
+    }
+    if (node.type === 'embed') {
+      return `[${node.label}](${node.url})`;
     }
     return '';
   },

--- a/agents/skills/distill-page/test/cdp.test.ts
+++ b/agents/skills/distill-page/test/cdp.test.ts
@@ -107,6 +107,19 @@ test('does not treat large ordered-list text as headings', async () => {
   );
 });
 
+test('replaces a failed iframe with a link', async () => {
+  const fixturePath = path.resolve(__dirname, 'fixtures', 'blocked-iframe.html');
+  const content = await fetchDistilledBase64(`file://${fixturePath}`);
+  const markdown = convertToMarkdown(decodeAnnotatedPageContent(content));
+
+  assert.ok(
+    markdown.includes('[Link to codepen.io embed](https://codepen.io/web-dot-dev/embed/preview/WNRemxN?editable=true)'),
+    'Should replace the failed embed with a link to the CodePen',
+  );
+  assert.ok(!markdown.includes('refused to connect'), 'Should omit the iframe failure message');
+  assert.ok(markdown.includes('Content after the embed.'), 'Should preserve content after the iframe');
+});
+
 test('CDP Page.getAnnotatedPageContent on mock-page.html', async () => {
   const mockPagePath = path.resolve(__dirname, 'fixtures/mock-page.html');
   const mockPageUrl = `file://${mockPagePath}`;

--- a/agents/skills/distill-page/test/decode.test.ts
+++ b/agents/skills/distill-page/test/decode.test.ts
@@ -5,7 +5,7 @@ import type {JsonValue} from '@bufbuild/protobuf';
 import {AnnotatedPageContentSchema, ContentAttributeType} from '../scripts/proto/common_quality_data_pb.js';
 import {decodeAnnotatedPageContent, convertToMarkdown} from '../scripts/distill-page.ts';
 
-const {CONTENT_ATTRIBUTE_TEXT} = ContentAttributeType;
+const {CONTENT_ATTRIBUTE_TEXT, CONTENT_ATTRIBUTE_IMAGE, CONTENT_ATTRIBUTE_IFRAME} = ContentAttributeType;
 
 function getMarkdown(payload: JsonValue): string {
   const buffer = toBinary(AnnotatedPageContentSchema, fromJson(AnnotatedPageContentSchema, payload));
@@ -58,4 +58,49 @@ test('convertToMarkdown skips nodes and children if isAdRelated is true', () => 
   };
   const md = getMarkdown(payload);
   assert.strictEqual(md, 'Non-ad content.');
+});
+
+test('convertToMarkdown replaces a failed CodePen iframe with a link', () => {
+  const payload: JsonValue = {
+    rootNode: {
+      childrenNodes: [
+        {
+          contentAttributes: {
+            attributeType: CONTENT_ATTRIBUTE_IFRAME,
+            iframeData: {
+              frameData: {
+                url: 'https://codepen.io/example/embed/preview/bJOrK?editable=true',
+                title: 'codepen.io',
+              },
+            },
+          },
+          childrenNodes: [
+            {
+              contentAttributes: {
+                attributeType: CONTENT_ATTRIBUTE_IMAGE,
+                imageData: {},
+              },
+            },
+            {
+              contentAttributes: {
+                attributeType: CONTENT_ATTRIBUTE_TEXT,
+                textData: {textContent: 'codepen.io'},
+              },
+            },
+            {
+              contentAttributes: {
+                attributeType: CONTENT_ATTRIBUTE_TEXT,
+                textData: {textContent: ' refused to connect.'},
+              },
+            },
+          ],
+        },
+      ],
+    },
+  };
+
+  assert.strictEqual(
+    getMarkdown(payload),
+    '[Link to codepen.io embed](https://codepen.io/example/embed/preview/bJOrK?editable=true)',
+  );
 });

--- a/agents/skills/distill-page/test/fixtures/blocked-iframe.html
+++ b/agents/skills/distill-page/test/fixtures/blocked-iframe.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Blocked iframe</title>
+  </head>
+  <body>
+    <main>
+      <h1>Embedded demo</h1>
+      <iframe title="Demo embed" src="https://codepen.io/web-dot-dev/embed/preview/WNRemxN?editable=true"></iframe>
+      <p>Content after the embed.</p>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
Some iframes refuse to load in playwright for whatever reason. The problem is that the annotation decoder will spit out the refusal as if it were content, and you have no idea what was there when you're looking at the markdown later.

For instance, with a page that contains a codepen embed, you'll end up with a line like `**codepen.io** refused to connect.`

This PR replaces that with a link that, for that example, will say `[Link to codepen.io embed](https://codepen.io/...)'`.

For any iframe that doesn't fit that pattern, it goes through the same pipeline as before (so e.g. youtube embeds continue working exactly as they did before this change).

Unfortunately there's not an easy way to tell in the annotation tree that there's a failed iframe. The closest I could get is that it always has text nodes with the embed's hostname and the string `'refused to connect.'` That string [has been in Chromium since 2016](https://source.chromium.org/chromium/chromium/src/+/main:components/strings/components_strings_en-GB.xtb;l=3227;drc=c82c85f92350bcf37a823766002f75355d0e167b), so we can at least assume it's fairly stable. It is subject to change, though, and it relies on running distill-page in english, though. Open to other ideas!