### PR TITLE
[distill-page] no leaking code markers in nested <pre>s

### DIFF
--- a/agents/skills/distill-page/scripts/distill-page.ts
+++ b/agents/skills/distill-page/scripts/distill-page.ts
@@ -20,10 +20,9 @@ export async function injectSemanticMarkers(page: any) {
     inlineCodeCloseMarker: string;
   }) => {
     document.querySelectorAll('code').forEach(el => {
-      if (!el.closest('pre')) {
-        el.insertAdjacentText('afterbegin', inlineCodeOpenMarker);
-        el.insertAdjacentText('beforeend', inlineCodeCloseMarker);
-      }
+      if (el.closest('pre') || el.parentElement?.closest('code')) return;
+      el.insertAdjacentText('afterbegin', inlineCodeOpenMarker);
+      el.insertAdjacentText('beforeend', inlineCodeCloseMarker);
     });
     document.querySelectorAll('pre').forEach(el => {
       // Syntax highlighters can produce nested <pre> elements. Mark the

--- a/agents/skills/distill-page/scripts/distill-page.ts
+++ b/agents/skills/distill-page/scripts/distill-page.ts
@@ -26,6 +26,9 @@ export async function injectSemanticMarkers(page: any) {
       }
     });
     document.querySelectorAll('pre').forEach(el => {
+      // Syntax highlighters can produce nested <pre> elements. Mark the
+      // outermost block once so nested markers do not become code content.
+      if (el.parentElement?.closest('pre')) return;
       el.insertAdjacentText('afterbegin', preOpenMarker);
       el.insertAdjacentText('beforeend', preCloseMarker);
     });

--- a/agents/skills/distill-page/test/cdp.test.ts
+++ b/agents/skills/distill-page/test/cdp.test.ts
@@ -89,6 +89,11 @@ test('uses the primary main landmark in the stress fixture', async () => {
   assert.ok(markdown.includes('FENCES-AFTER-SENTINEL'), 'Should not treat literal Markdown fences in prose as code-block boundaries');
   assert.ok(markdown.includes('type ```` ```shell````'), 'Should use a safe inline-code delimiter around literal Markdown fences');
   assert.ok(markdown.includes('```\nrg --files notes | sort\ngit status --short\n```'), 'Should preserve the real preformatted code block');
+  assert.ok(
+    markdown.includes('```\n/* NESTED-PRE-CODE-SENTINEL */\n.nested-pre { color: darkseagreen; }\n```'),
+    'Should fence nested pre elements once without leaking semantic markers',
+  );
+  assert.ok(!markdown.includes('distill-page-pre-'), 'Should not leak preformatted-block semantic markers');
 });
 
 test('does not treat large ordered-list text as headings', async () => {

--- a/agents/skills/distill-page/test/cdp.test.ts
+++ b/agents/skills/distill-page/test/cdp.test.ts
@@ -88,6 +88,10 @@ test('uses the primary main landmark in the stress fixture', async () => {
   assert.ok(!markdown.includes('PREVIEW-ONLY-SENTINEL'), 'Should exclude the competing preview main landmark');
   assert.ok(markdown.includes('FENCES-AFTER-SENTINEL'), 'Should not treat literal Markdown fences in prose as code-block boundaries');
   assert.ok(markdown.includes('type ```` ```shell````'), 'Should use a safe inline-code delimiter around literal Markdown fences');
+  assert.ok(
+    markdown.includes('NESTED-INLINE-CODE-SENTINEL: `outer inner tail`.'),
+    'Should preserve nested inline code as one code span',
+  );
   assert.ok(markdown.includes('```\nrg --files notes | sort\ngit status --short\n```'), 'Should preserve the real preformatted code block');
   assert.ok(
     markdown.includes('```\n/* NESTED-PRE-CODE-SENTINEL */\n.nested-pre { color: darkseagreen; }\n```'),

--- a/agents/skills/distill-page/test/fixtures/extractor-stress-cases.html
+++ b/agents/skills/distill-page/test/fixtures/extractor-stress-cases.html
@@ -62,6 +62,7 @@
 
         <section aria-labelledby="fences-heading">
           <h2 id="fences-heading">When prose discusses Markdown</h2>
+          <p>NESTED-INLINE-CODE-SENTINEL: <code>outer <code>inner</code> tail</code>.</p>
           <p>FENCES-BEFORE-SENTINEL: The editor’s instructions literally say: type <code>```shell</code>, paste the command, then type <code>```</code> on a line by itself. Those characters are prose, not a code block boundary.</p>
           <figure>
             <figcaption>An actual command from the checklist</figcaption>

--- a/agents/skills/distill-page/test/fixtures/extractor-stress-cases.html
+++ b/agents/skills/distill-page/test/fixtures/extractor-stress-cases.html
@@ -68,6 +68,11 @@
             <pre tabindex="0"><code class="language-shell">rg --files notes | sort
 git status --short</code></pre>
           </figure>
+          <figure>
+            <figcaption>A syntax-highlighted block with nested pre elements</figcaption>
+            <pre><code class="language-css"><pre class="shiki"><code><span class="line">/* NESTED-PRE-CODE-SENTINEL */</span>
+<span class="line">.nested-pre { color: darkseagreen; }</span></code></pre></code></pre>
+          </figure>
           <p>FENCES-AFTER-SENTINEL: This paragraph must remain ordinary narrative after the real code sample.</p>
         </section>
 


### PR DESCRIPTION
I don't know why you'd want to do this, but people do. Nested `<pre>` elements will end up with the pre open and close markers in the markdown output. The easiest fix seemed to be what is done for inline `<code>`, and not add marks if inside another `<pre>` element

---

Fixes:
- Currently
  ```
  <pre><code class="language-css"><pre class="shiki"><code><span class="line">/* NESTED-PRE-CODE-SENTINEL */</span>
  <span class="line">.nested-pre { color: darkseagreen; }</span></code></pre></code></pre>
  ```
  produces:
  ````
  ```
  distill-page-pre-open/* NESTED-PRE-CODE-SENTINEL */
  .nested-pre { color: darkseagreen; }distill-page-pre-close
  ```
  ````
  this change prevents insertion of the semantic pre-open/pre-close markers into the inner code block

- Currently
  ```
  <p>NESTED-INLINE-CODE-SENTINEL: <code>outer <code>inner</code> tail</code>.</p>
  ```
  produces:
  ```
  NESTED-INLINE-CODE-SENTINEL: `outer inner` tail.
  ```
  this change makes the parser look to the outermost `<code>` and now produces the (hopefully) less surprising:
  ```
  NESTED-INLINE-CODE-SENTINEL: `outer inner tail`.
  ```