### PR TITLE
distill-page: embolden text in runs of children

### DIFF
--- a/agents/skills/distill-page/scripts/decode_annotations.ts
+++ b/agents/skills/distill-page/scripts/decode_annotations.ts
@@ -787,10 +787,36 @@ export const MarkdownSerializer = {
       grouped.push(this.mergeGroup(currentGroup, !!currentBold, !!currentCode));
     }
 
+    const isEmphasizedText = (node: ASTInlineNode): node is ASTTextRun => {
+      // Policy decision: Suppress emphasis wrapping (bold) inside link tags.
+      // The Chromium layout annotator model flags all link text runs as having
+      // emphasis due to visual color/styling differences. Bolding every link
+      // creates significant visual clutter.
+      return node.type === 'text' && !!node.style?.hasEmphasis && !insideLink;
+    }
+
     let md = '';
-    for (let i = 0; i < grouped.length; i++) {
+    for (let i = 0; i < grouped.length;) {
       const child = grouped[i];
-      const chunk = this.serializeInline(child, insideLink);
+      let chunk = '';
+
+      // Embolden text once per run of successive emphasized text nodes, rather than child by child.
+      if (isEmphasizedText(child)) {
+        let contents = '';
+        while (i < grouped.length) {
+          const run = grouped[i];
+          if (!isEmphasizedText(run)) break;
+          const part = this.serializeText(run);
+          if (this.shouldInsertSpace(contents, part)) contents += ' ';
+          contents += part;
+          i++;
+        }
+        chunk = `**${contents}**`;
+      } else {
+        chunk = this.serializeInline(child);
+        i++;
+      }
+
       if (!chunk) continue;
 
       if (this.shouldInsertSpace(md, chunk)) {
@@ -799,6 +825,10 @@ export const MarkdownSerializer = {
       md += chunk;
     }
     return md.trim();
+  },
+
+  serializeText(node: ASTTextRun): string {
+    return node.isCode ? this.serializeCodeSpan(node.text) : node.text;
   },
 
   serializeImage(node: ASTImage): string {
@@ -816,20 +846,9 @@ export const MarkdownSerializer = {
     return `${delimiter}${content}${delimiter}`;
   },
 
-  serializeInline(node: ASTInlineNode, insideLink = false): string {
+  serializeInline(node: ASTInlineNode): string {
     if (node.type === 'text') {
-      let text = node.text;
-      if (node.isCode) {
-        text = this.serializeCodeSpan(text);
-      }
-      // Policy decision: Suppress emphasis wrapping (bold) inside link tags.
-      // The Chromium layout annotator model flags all link text runs as having
-      // emphasis due to visual color/styling differences. Bolding every link
-      // creates significant visual clutter.
-      if (node.style?.hasEmphasis && !insideLink) {
-        text = `**${text}**`;
-      }
-      return text;
+      return this.serializeText(node);
     }
     if (node.type === 'link') {
       const linkText = this.serializeInlineChildren(node.children, true);
@@ -873,7 +892,7 @@ export const MarkdownSerializer = {
               return this.serializeInlineChildren(child.children);
             }
             if (child.type === 'text' || child.type === 'link') {
-              return this.serializeInline(child);
+              return this.serializeInlineChildren([child]);
             }
             return this.serializeBlock(child as ASTBlockNode);
           })

--- a/agents/skills/distill-page/scripts/decode_annotations.ts
+++ b/agents/skills/distill-page/scripts/decode_annotations.ts
@@ -1,5 +1,5 @@
 import {fromBinary, create} from '@bufbuild/protobuf';
-import {AnnotatedPageContentSchema, AnnotatedRole, ContentAttributeType, TextSize, TableRowType, TextStyleSchema, ContentNodeSchema} from './proto/common_quality_data_pb.js';
+import {AnnotatedPageContentSchema, AnnotatedRole, ContentAttributeType, TextSize, TableRowType, ContentNodeSchema} from './proto/common_quality_data_pb.js';
 import type {ContentNode, AnnotatedPageContent, TextInfo, ImageInfo, AnchorData, TableData, IframeData} from './proto/common_quality_data_pb.js';
 import {INLINE_CODE_CLOSE_MARKER, INLINE_CODE_OPEN_MARKER, PRE_CLOSE_MARKER, PRE_OPEN_MARKER} from './semantic_markers.ts';
 
@@ -44,6 +44,7 @@ export interface ASTEmbed {
 }
 
 export type ASTInlineNode = ASTTextRun | ASTLink | ASTImage | ASTEmbed;
+export type ASTNonTextInlineNode = Exclude<ASTInlineNode, ASTTextRun>;
 
 export interface ASTParagraph {
   type: 'paragraph';
@@ -723,112 +724,73 @@ export const MarkdownSerializer = {
     return !startsWithPunc && !endsWithSkip;
   },
 
-  mergeGroup(group: ASTInlineNode[], bold: boolean, isCode: boolean): ASTInlineNode {
-    if (group.length === 1) return group[0];
-
-    let texts = '';
-    for (let i = 0; i < group.length; i++) {
-      const node = group[i];
-      if (node.type !== 'text') continue;
-      const chunk = node.text;
-      if (!chunk) continue;
-
-      if (this.shouldInsertSpace(texts, chunk)) {
-        texts += ' ';
-      }
-      texts += chunk;
-    }
-
-    const first = group[0];
-    if (first.type === 'text') {
-      return {
-        type: 'text',
-        text: texts,
-        style: first.style ? create(TextStyleSchema, {...first.style, hasEmphasis: bold}) : bold ? create(TextStyleSchema, {hasEmphasis: true}) : undefined,
-        isCode,
-      };
-    }
-    return first;
+  append(appendee: string, appendix: string) {
+    if (!appendix) return appendee;
+    const spacer = this.shouldInsertSpace(appendee, appendix) ? ' ' : '';
+    return appendee + spacer + appendix;
   },
 
   serializeInlineChildren(children: ASTInlineNode[], insideLink = false): string {
-    const grouped: ASTInlineNode[] = [];
-    let currentGroup: ASTInlineNode[] = [];
-    let currentBold: boolean | undefined = undefined;
-    let currentCode: boolean | undefined = undefined;
-
-    for (const child of children) {
-      if (child.type === 'text') {
-        const isBold = !!(child.style?.hasEmphasis && !insideLink);
-        const isCode = !!child.isCode;
-        if (currentBold === undefined) {
-          currentBold = isBold;
-          currentCode = isCode;
-          currentGroup.push(child);
-        } else if (currentBold === isBold && currentCode === isCode) {
-          currentGroup.push(child);
-        } else {
-          grouped.push(this.mergeGroup(currentGroup, currentBold, !!currentCode));
-          currentGroup = [child];
-          currentBold = isBold;
-          currentCode = isCode;
-        }
-      } else {
-        if (currentGroup.length > 0) {
-          grouped.push(this.mergeGroup(currentGroup, !!currentBold, !!currentCode));
-          currentGroup = [];
-          currentBold = undefined;
-          currentCode = undefined;
-        }
-        grouped.push(child);
-      }
-    }
-    if (currentGroup.length > 0) {
-      grouped.push(this.mergeGroup(currentGroup, !!currentBold, !!currentCode));
-    }
-
-    const isEmphasizedText = (node: ASTInlineNode): node is ASTTextRun => {
+    const isBold = (node: ASTTextRun): boolean => {
       // Policy decision: Suppress emphasis wrapping (bold) inside link tags.
       // The Chromium layout annotator model flags all link text runs as having
       // emphasis due to visual color/styling differences. Bolding every link
       // creates significant visual clutter.
-      return node.type === 'text' && !!node.style?.hasEmphasis && !insideLink;
-    }
+      return !!node.style?.hasEmphasis && !insideLink;
+    };
+    const appendCodeOrText = (base: string, text: string, isCode: boolean): string => {
+      const serialized = isCode ? this.serializeCodeSpan(text) : text;
+      return this.append(base, serialized);
+    };
+    const appendBoldOrText = (base: string, text: string, isBold: boolean): string => {
+      const serialized = isBold ? `**${text}**` : text;
+      return this.append(base, serialized);
+    };
 
     let md = '';
-    for (let i = 0; i < grouped.length;) {
-      const child = grouped[i];
-      let chunk = '';
+    for (let i = 0; i < children.length;) {
+      const childPeek = children[i];
 
-      // Embolden text once per run of successive emphasized text nodes, rather than child by child.
-      if (isEmphasizedText(child)) {
-        let contents = '';
-        while (i < grouped.length) {
-          const run = grouped[i];
-          if (!isEmphasizedText(run)) break;
-          const part = this.serializeText(run);
-          if (this.shouldInsertSpace(contents, part)) contents += ' ';
-          contents += part;
-          i++;
-        }
-        chunk = `**${contents}**`;
-      } else {
-        chunk = this.serializeInline(child);
+      // Not text, so just append and move on.
+      if (childPeek.type !== 'text') {
+        const serialized = this.serializeNonTextInline(childPeek);
+        md = this.append(md, serialized);
         i++;
+        continue;
       }
 
-      if (!chunk) continue;
+      // We want to only add enter and exit markers for inline bold and code text when needed, so
+      // sibling text in the same state of each should be merged before putting markers around them.
+      // Find code sub-runs inside each run of bold (or not) text, so they can contain multiple
+      // code segments.
+      // - the outer loop looks for boldness runs: consecutive text nodes with the same isBold state
+      // - within boldness runs, the inner loop looks for "codeness" segments: consecutive nodes of the same isCode state
+      const isBoldRun = isBold(childPeek);
+      let boldnessRun = '';
+      let isCodeSegment = !!childPeek.isCode;
+      let codenessSegment = '';
 
-      if (this.shouldInsertSpace(md, chunk)) {
-        md += ' ';
+      // Go until we run out of text in a isBoldRun state.
+      for (; i < children.length; i++) {
+        const next = children[i];
+        if (next.type !== 'text' || isBold(next) !== isBoldRun) break;
+
+        // Flush codenessSegment to the boldnessRun when isCode changes.
+        const isCode = !!next.isCode;
+        if (isCodeSegment !== isCode) {
+          boldnessRun = appendCodeOrText(boldnessRun, codenessSegment, isCodeSegment);
+          codenessSegment = '';
+          isCodeSegment = isCode;
+        }
+        // For each same-isCode text, accumulate in codenessSegment.
+        codenessSegment = this.append(codenessSegment, next.text);
       }
-      md += chunk;
+      boldnessRun = appendCodeOrText(boldnessRun, codenessSegment, isCodeSegment);
+
+      md = appendBoldOrText(md, boldnessRun, isBoldRun);
     }
-    return md.trim();
-  },
 
-  serializeText(node: ASTTextRun): string {
-    return node.isCode ? this.serializeCodeSpan(node.text) : node.text;
+    return md.trim();
   },
 
   serializeImage(node: ASTImage): string {
@@ -846,10 +808,7 @@ export const MarkdownSerializer = {
     return `${delimiter}${content}${delimiter}`;
   },
 
-  serializeInline(node: ASTInlineNode): string {
-    if (node.type === 'text') {
-      return this.serializeText(node);
-    }
+  serializeNonTextInline(node: ASTNonTextInlineNode): string {
     if (node.type === 'link') {
       const linkText = this.serializeInlineChildren(node.children, true);
       if (linkText && node.data.url) {
@@ -863,7 +822,9 @@ export const MarkdownSerializer = {
     if (node.type === 'embed') {
       return `[${node.label}](${node.url})`;
     }
-    return '';
+
+    node satisfies never;
+    throw new Error('Unsupported inline node');
   },
 
   serializeBlock(node: ASTBlockNode): string {

--- a/agents/skills/distill-page/scripts/distill-page.ts
+++ b/agents/skills/distill-page/scripts/distill-page.ts
@@ -20,10 +20,9 @@ export async function injectSemanticMarkers(page: any) {
     inlineCodeCloseMarker: string;
   }) => {
     document.querySelectorAll('code').forEach(el => {
-      if (!el.closest('pre')) {
-        el.insertAdjacentText('afterbegin', inlineCodeOpenMarker);
-        el.insertAdjacentText('beforeend', inlineCodeCloseMarker);
-      }
+      if (el.closest('pre') || el.parentElement?.closest('code')) return;
+      el.insertAdjacentText('afterbegin', inlineCodeOpenMarker);
+      el.insertAdjacentText('beforeend', inlineCodeCloseMarker);
     });
     document.querySelectorAll('pre').forEach(el => {
       // Syntax highlighters can produce nested <pre> elements. Mark the

--- a/agents/skills/distill-page/scripts/distill-page.ts
+++ b/agents/skills/distill-page/scripts/distill-page.ts
@@ -26,6 +26,9 @@ export async function injectSemanticMarkers(page: any) {
       }
     });
     document.querySelectorAll('pre').forEach(el => {
+      // Syntax highlighters can produce nested <pre> elements. Mark the
+      // outermost block once so nested markers do not become code content.
+      if (el.parentElement?.closest('pre')) return;
       el.insertAdjacentText('afterbegin', preOpenMarker);
       el.insertAdjacentText('beforeend', preCloseMarker);
     });

--- a/agents/skills/distill-page/test/cdp.test.ts
+++ b/agents/skills/distill-page/test/cdp.test.ts
@@ -89,6 +89,11 @@ test('uses the primary main landmark in the stress fixture', async () => {
   assert.ok(markdown.includes('FENCES-AFTER-SENTINEL'), 'Should not treat literal Markdown fences in prose as code-block boundaries');
   assert.ok(markdown.includes('type ```` ```shell````'), 'Should use a safe inline-code delimiter around literal Markdown fences');
   assert.ok(markdown.includes('```\nrg --files notes | sort\ngit status --short\n```'), 'Should preserve the real preformatted code block');
+  assert.ok(
+    markdown.includes('```\n/* NESTED-PRE-CODE-SENTINEL */\n.nested-pre { color: darkseagreen; }\n```'),
+    'Should fence nested pre elements once without leaking semantic markers',
+  );
+  assert.ok(!markdown.includes('distill-page-pre-'), 'Should not leak preformatted-block semantic markers');
 });
 
 test('does not treat large ordered-list text as headings', async () => {

--- a/agents/skills/distill-page/test/cdp.test.ts
+++ b/agents/skills/distill-page/test/cdp.test.ts
@@ -88,6 +88,10 @@ test('uses the primary main landmark in the stress fixture', async () => {
   assert.ok(!markdown.includes('PREVIEW-ONLY-SENTINEL'), 'Should exclude the competing preview main landmark');
   assert.ok(markdown.includes('FENCES-AFTER-SENTINEL'), 'Should not treat literal Markdown fences in prose as code-block boundaries');
   assert.ok(markdown.includes('type ```` ```shell````'), 'Should use a safe inline-code delimiter around literal Markdown fences');
+  assert.ok(
+    markdown.includes('NESTED-INLINE-CODE-SENTINEL: `outer inner tail`.'),
+    'Should preserve nested inline code as one code span',
+  );
   assert.ok(markdown.includes('```\nrg --files notes | sort\ngit status --short\n```'), 'Should preserve the real preformatted code block');
   assert.ok(
     markdown.includes('```\n/* NESTED-PRE-CODE-SENTINEL */\n.nested-pre { color: darkseagreen; }\n```'),

--- a/agents/skills/distill-page/test/cdp.test.ts
+++ b/agents/skills/distill-page/test/cdp.test.ts
@@ -101,6 +101,10 @@ test('uses the primary main landmark in the stress fixture', async () => {
     'Should preserve spaces at the boundaries of emphasis containing inline code',
   );
   assert.ok(
+    markdown.includes('EMPHASIS-CODE-EDGES-BEFORE **`leading` bold middle `trailing`** EMPHASIS-CODE-EDGES-AFTER.'),
+    'Should preserve an emphasis run that starts and ends with inline code',
+  );
+  assert.ok(
     markdown.includes('CODE-LINK-SENTINEL: Read [`API.method()`](https://example.com/api) for details.'),
     'Should preserve inline code nested inside a link',
   );

--- a/agents/skills/distill-page/test/cdp.test.ts
+++ b/agents/skills/distill-page/test/cdp.test.ts
@@ -89,6 +89,22 @@ test('uses the primary main landmark in the stress fixture', async () => {
   assert.ok(markdown.includes('FENCES-AFTER-SENTINEL'), 'Should not treat literal Markdown fences in prose as code-block boundaries');
   assert.ok(markdown.includes('type ```` ```shell````'), 'Should use a safe inline-code delimiter around literal Markdown fences');
   assert.ok(
+    markdown.includes('**EMPHASIS-CODE-SENTINEL: Inline `auto`. Then `0` remains inside one emphasized sentence.**'),
+    'Should keep inline code inside a continuous emphasis span',
+  );
+  assert.ok(
+    markdown.includes('**CSS-EMPHASIS-CODE-SENTINEL: Inline `min-content` remains inside CSS-derived emphasis.**'),
+    'Should keep inline code inside CSS-derived emphasis',
+  );
+  assert.ok(
+    markdown.includes('EMPHASIS-BOUNDARIES-BEFORE **bold before `nested` bold after** EMPHASIS-BOUNDARIES-AFTER.'),
+    'Should preserve spaces at the boundaries of emphasis containing inline code',
+  );
+  assert.ok(
+    markdown.includes('CODE-LINK-SENTINEL: Read [`API.method()`](https://example.com/api) for details.'),
+    'Should preserve inline code nested inside a link',
+  );
+  assert.ok(
     markdown.includes('NESTED-INLINE-CODE-SENTINEL: `outer inner tail`.'),
     'Should preserve nested inline code as one code span',
   );

--- a/agents/skills/distill-page/test/decode.test.ts
+++ b/agents/skills/distill-page/test/decode.test.ts
@@ -4,9 +4,8 @@ import {fromJson, toBinary} from '@bufbuild/protobuf';
 import type {JsonValue} from '@bufbuild/protobuf';
 import {AnnotatedPageContentSchema, ContentAttributeType} from '../scripts/proto/common_quality_data_pb.js';
 import {decodeAnnotatedPageContent, convertToMarkdown} from '../scripts/distill-page.ts';
-import {INLINE_CODE_CLOSE_MARKER, INLINE_CODE_OPEN_MARKER} from '../scripts/semantic_markers.ts';
 
-const {CONTENT_ATTRIBUTE_TEXT, CONTENT_ATTRIBUTE_IMAGE, CONTENT_ATTRIBUTE_IFRAME, CONTENT_ATTRIBUTE_PARAGRAPH} = ContentAttributeType;
+const {CONTENT_ATTRIBUTE_TEXT, CONTENT_ATTRIBUTE_IMAGE, CONTENT_ATTRIBUTE_IFRAME} = ContentAttributeType;
 
 function getMarkdown(payload: JsonValue): string {
   const buffer = toBinary(AnnotatedPageContentSchema, fromJson(AnnotatedPageContentSchema, payload));
@@ -103,42 +102,5 @@ test('convertToMarkdown replaces a failed CodePen iframe with a link', () => {
   assert.strictEqual(
     getMarkdown(payload),
     '[Link to codepen.io embed](https://codepen.io/example/embed/preview/bJOrK?editable=true)',
-  );
-});
-
-test('convertToMarkdown keeps inline code inside a continuous emphasis span', () => {
-  const textNode = (textContent: string): JsonValue => ({
-    contentAttributes: {
-      attributeType: CONTENT_ATTRIBUTE_TEXT,
-      textData: {
-        textContent,
-        textStyle: {hasEmphasis: true},
-      },
-    },
-  });
-  const payload: JsonValue = {
-    rootNode: {
-      childrenNodes: [
-        {
-          contentAttributes: {attributeType: CONTENT_ATTRIBUTE_PARAGRAPH},
-          childrenNodes: [
-            textNode('The minimum width of grid and flex children is '),
-            textNode(INLINE_CODE_OPEN_MARKER),
-            textNode('auto'),
-            textNode(INLINE_CODE_CLOSE_MARKER),
-            textNode('. Setting it explicitly to '),
-            textNode(INLINE_CODE_OPEN_MARKER),
-            textNode('0'),
-            textNode(INLINE_CODE_CLOSE_MARKER),
-            textNode(' removes the intrinsic size, unlocking various things.'),
-          ],
-        },
-      ],
-    },
-  };
-
-  assert.strictEqual(
-    getMarkdown(payload),
-    '**The minimum width of grid and flex children is `auto`. Setting it explicitly to `0` removes the intrinsic size, unlocking various things.**',
   );
 });

--- a/agents/skills/distill-page/test/decode.test.ts
+++ b/agents/skills/distill-page/test/decode.test.ts
@@ -4,8 +4,9 @@ import {fromJson, toBinary} from '@bufbuild/protobuf';
 import type {JsonValue} from '@bufbuild/protobuf';
 import {AnnotatedPageContentSchema, ContentAttributeType} from '../scripts/proto/common_quality_data_pb.js';
 import {decodeAnnotatedPageContent, convertToMarkdown} from '../scripts/distill-page.ts';
+import {INLINE_CODE_CLOSE_MARKER, INLINE_CODE_OPEN_MARKER} from '../scripts/semantic_markers.ts';
 
-const {CONTENT_ATTRIBUTE_TEXT, CONTENT_ATTRIBUTE_IMAGE, CONTENT_ATTRIBUTE_IFRAME} = ContentAttributeType;
+const {CONTENT_ATTRIBUTE_TEXT, CONTENT_ATTRIBUTE_IMAGE, CONTENT_ATTRIBUTE_IFRAME, CONTENT_ATTRIBUTE_PARAGRAPH} = ContentAttributeType;
 
 function getMarkdown(payload: JsonValue): string {
   const buffer = toBinary(AnnotatedPageContentSchema, fromJson(AnnotatedPageContentSchema, payload));
@@ -102,5 +103,42 @@ test('convertToMarkdown replaces a failed CodePen iframe with a link', () => {
   assert.strictEqual(
     getMarkdown(payload),
     '[Link to codepen.io embed](https://codepen.io/example/embed/preview/bJOrK?editable=true)',
+  );
+});
+
+test('convertToMarkdown keeps inline code inside a continuous emphasis span', () => {
+  const textNode = (textContent: string): JsonValue => ({
+    contentAttributes: {
+      attributeType: CONTENT_ATTRIBUTE_TEXT,
+      textData: {
+        textContent,
+        textStyle: {hasEmphasis: true},
+      },
+    },
+  });
+  const payload: JsonValue = {
+    rootNode: {
+      childrenNodes: [
+        {
+          contentAttributes: {attributeType: CONTENT_ATTRIBUTE_PARAGRAPH},
+          childrenNodes: [
+            textNode('The minimum width of grid and flex children is '),
+            textNode(INLINE_CODE_OPEN_MARKER),
+            textNode('auto'),
+            textNode(INLINE_CODE_CLOSE_MARKER),
+            textNode('. Setting it explicitly to '),
+            textNode(INLINE_CODE_OPEN_MARKER),
+            textNode('0'),
+            textNode(INLINE_CODE_CLOSE_MARKER),
+            textNode(' removes the intrinsic size, unlocking various things.'),
+          ],
+        },
+      ],
+    },
+  };
+
+  assert.strictEqual(
+    getMarkdown(payload),
+    '**The minimum width of grid and flex children is `auto`. Setting it explicitly to `0` removes the intrinsic size, unlocking various things.**',
   );
 });

--- a/agents/skills/distill-page/test/fixtures/extractor-stress-cases.html
+++ b/agents/skills/distill-page/test/fixtures/extractor-stress-cases.html
@@ -62,6 +62,7 @@
 
         <section aria-labelledby="fences-heading">
           <h2 id="fences-heading">When prose discusses Markdown</h2>
+          <p>NESTED-INLINE-CODE-SENTINEL: <code>outer <code>inner</code> tail</code>.</p>
           <p>FENCES-BEFORE-SENTINEL: The editor’s instructions literally say: type <code>```shell</code>, paste the command, then type <code>```</code> on a line by itself. Those characters are prose, not a code block boundary.</p>
           <figure>
             <figcaption>An actual command from the checklist</figcaption>

--- a/agents/skills/distill-page/test/fixtures/extractor-stress-cases.html
+++ b/agents/skills/distill-page/test/fixtures/extractor-stress-cases.html
@@ -65,6 +65,7 @@
           <p><strong>EMPHASIS-CODE-SENTINEL: Inline <code>auto</code>. Then <code>0</code> remains inside one emphasized sentence.</strong></p>
           <p style="font-weight: 700">CSS-EMPHASIS-CODE-SENTINEL: Inline <code>min-content</code> remains inside CSS-derived emphasis.</p>
           <p>EMPHASIS-BOUNDARIES-BEFORE <strong>bold before <code>nested</code> bold after</strong> EMPHASIS-BOUNDARIES-AFTER.</p>
+          <p>EMPHASIS-CODE-EDGES-BEFORE <strong><code>leading</code> bold middle <code>trailing</code></strong> EMPHASIS-CODE-EDGES-AFTER.</p>
           <p>CODE-LINK-SENTINEL: Read <a href="https://example.com/api"><code>API.method()</code></a> for details.</p>
           <p>NESTED-INLINE-CODE-SENTINEL: <code>outer <code>inner</code> tail</code>.</p>
           <p>FENCES-BEFORE-SENTINEL: The editor’s instructions literally say: type <code>```shell</code>, paste the command, then type <code>```</code> on a line by itself. Those characters are prose, not a code block boundary.</p>

--- a/agents/skills/distill-page/test/fixtures/extractor-stress-cases.html
+++ b/agents/skills/distill-page/test/fixtures/extractor-stress-cases.html
@@ -68,6 +68,11 @@
             <pre tabindex="0"><code class="language-shell">rg --files notes | sort
 git status --short</code></pre>
           </figure>
+          <figure>
+            <figcaption>A syntax-highlighted block with nested pre elements</figcaption>
+            <pre><code class="language-css"><pre class="shiki"><code><span class="line">/* NESTED-PRE-CODE-SENTINEL */</span>
+<span class="line">.nested-pre { color: darkseagreen; }</span></code></pre></code></pre>
+          </figure>
           <p>FENCES-AFTER-SENTINEL: This paragraph must remain ordinary narrative after the real code sample.</p>
         </section>
 

--- a/agents/skills/distill-page/test/fixtures/extractor-stress-cases.html
+++ b/agents/skills/distill-page/test/fixtures/extractor-stress-cases.html
@@ -62,6 +62,10 @@
 
         <section aria-labelledby="fences-heading">
           <h2 id="fences-heading">When prose discusses Markdown</h2>
+          <p><strong>EMPHASIS-CODE-SENTINEL: Inline <code>auto</code>. Then <code>0</code> remains inside one emphasized sentence.</strong></p>
+          <p style="font-weight: 700">CSS-EMPHASIS-CODE-SENTINEL: Inline <code>min-content</code> remains inside CSS-derived emphasis.</p>
+          <p>EMPHASIS-BOUNDARIES-BEFORE <strong>bold before <code>nested</code> bold after</strong> EMPHASIS-BOUNDARIES-AFTER.</p>
+          <p>CODE-LINK-SENTINEL: Read <a href="https://example.com/api"><code>API.method()</code></a> for details.</p>
           <p>NESTED-INLINE-CODE-SENTINEL: <code>outer <code>inner</code> tail</code>.</p>
           <p>FENCES-BEFORE-SENTINEL: The editor’s instructions literally say: type <code>```shell</code>, paste the command, then type <code>```</code> on a line by itself. Those characters are prose, not a code block boundary.</p>
           <figure>


### PR DESCRIPTION
based on #133, so may want to diff against that or land that first. 

The change to grouping child text nodes was a big improvement, but one side effect was that it emphasizes text nodes individually. This can cause issues when you have things like `<code>` nested in emphasized text, e.g. `<strong>bold before <code>nested</code> bold after</strong>` becomes

```md
**bold before** **`nested`** **bold after**
```
basically un-bolding the spaces between the text nodes.

This change looks for runs of emphasized children and bolds them all at once, so that becomes

```md
**bold before `nested` bold after**
```

This actually dovetails nicely with the earlier code handling, and allows simplifying `serializeInline` at the same time, so emboldening is handled exclusively by `serializeInlineChildren`